### PR TITLE
feat: enhance BPF tracepoint handling and refactor scheduling logic

### DIFF
--- a/internal/bpf/tracepoint.go
+++ b/internal/bpf/tracepoint.go
@@ -82,33 +82,31 @@ func (t *tracing) trace(group, tracingName string, prog *ebpf.Program) error {
 	return nil
 }
 
-func Tracepoint(group string, progs map[string]*ebpf.Program) *tracing {
+func (t *tracing) Tracepoint(group string, progs map[string]*ebpf.Program) error {
 	log.Printf("正在附加 %s 组的 TracePoint 程序...\n", group)
 
-	var t tracing
 	for tracepointName, prog := range progs {
 		if err := t.trace(group, tracepointName, prog); err != nil {
-			log.Fatalf("附加 %s 组的 TracePoint 程序失败: %v", group, err)
+			return fmt.Errorf("附加 %s 组的 TracePoint 程序失败: %v", group, err)
 		}
 	}
 
-	return &t
+	return nil
 }
 
-func Tracing(group string, progs map[string]*ebpf.Program) *tracing {
+func (t *tracing) Tracing(group string, progs map[string]*ebpf.Program) error {
 	log.Printf("正在附加 %s 组的 tp_btf 程序...\n", group)
 
-	var t tracing
 	for _, prog := range progs {
 		tracing, err := link.AttachTracing(link.TracingOptions{Program: prog})
 		if err != nil {
-			log.Fatalf("附加 %s 组的 TracePoint 程序失败: %v", group, err)
+			return fmt.Errorf("附加 %s 组的 TracePoint 程序失败: %v", group, err)
 		}
 
 		t.addLink(tracing)
 	}
 
-	return &t
+	return nil
 }
 
 func IsTracepointExist(group, tracepointName string) bool {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -112,7 +112,7 @@ func Run(cfg config.Configuration) {
 	defer coll.Close()
 
 	// 附加调度跟踪点
-	schedTrace, err := bpf.AttachSchedTracepoint(coll)
+	schedTrace, err := bpf.AttachTracepointProgs(coll, bpf.SchedTracepointTargetProgs, "sched")
 	if err != nil {
 		log.Fatalf("Failed to attach sched tracepoint: %v", err)
 	}


### PR DESCRIPTION
- Introduced a new trace event structure for `sched_wakeup_new` to improve process wakeup tracking.
- Refactored the `sched_wakeup` and `sched_switch` functions to utilize a common handler for better code reuse and clarity.
- Updated the tracepoint attachment logic in Go to support both BPF tracepoints and BTF tracing, enhancing flexibility.
- Modified the `Run` function to reflect changes in tracepoint attachment, ensuring proper integration with the new structure.
- Improved logging and error handling in tracepoint attachment functions for better debugging and maintenance.