### PR TITLE
feat: enhance Makefile for deployment automation

### DIFF
--- a/cmd/config.yaml
+++ b/cmd/config.yaml
@@ -5,7 +5,7 @@ btf:
   kernel: "/sys/kernel/btf/vmlinux"
 
 output:
-  type: clickhouse
+  type: file
   clickhouse:
     host: "192.168.200.201"
     port: "9000"


### PR DESCRIPTION

- Added new targets in the Makefile for deployment automation, including connection checks and file copying to a remote host.
- Implemented retry logic for file copying to ensure robustness during deployment.
- Updated the output type in `config.yaml` from Clickhouse to file, reflecting a change in data handling strategy.
- Introduced a log checking mechanism to monitor deployment progress and timeout handling.